### PR TITLE
small blocks revision

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=1.1.5
+mod_version=1.1.6
 maven_group=com.terraformersmc
 archive_name=terraform
 

--- a/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
+++ b/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
@@ -306,13 +306,13 @@ public class SmallLogBlock extends Block implements Waterloggable {
 	@Override
 	public BlockState getPlacementState(ItemPlacementContext context) {
 
-		if (context.getPlayer() == null) {
-			return context.getWorld().getFluidState(context.getBlockPos()).equals(WATERLOGGED) ? this.getDefaultState().with(WATERLOGGED, true) : this.getDefaultState();
-		}
-
 		ViewableWorld world = context.getWorld();
 		BlockPos pos = context.getBlockPos();
 		FluidState fluid = context.getWorld().getFluidState(context.getBlockPos());
+
+		if (context.getPlayer() == null) {
+			return fluid.getFluid().equals(Fluids.WATER) ? this.getDefaultState().with(WATERLOGGED, true) : this.getDefaultState();
+		}
 
 		BlockPos upPos = pos.up();
 		BlockPos downPos = pos.down();

--- a/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
+++ b/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.block.*;
 import net.minecraft.entity.EntityContext;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
@@ -286,7 +287,29 @@ public class SmallLogBlock extends Block implements Waterloggable {
 	}
 
 	@Override
+	public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity entity, ItemStack stack) {
+		super.onPlaced(world, pos, state, entity, stack);
+
+		for (Direction direction : Direction.values()) {
+			if (world.getBlockState(pos.offset(direction)).getBlock() instanceof SmallLogBlock) {
+				world.setBlockState(pos.offset(direction),
+					getNeighborUpdateState(world.getBlockState(pos.offset(direction)),
+						direction.getOpposite(),
+						world.getBlockState(pos),
+						world,
+						pos.offset(direction),
+						pos));
+			}
+		}
+	}
+
+	@Override
 	public BlockState getPlacementState(ItemPlacementContext context) {
+
+		if (context.getPlayer() == null) {
+			return context.getWorld().getBlockState(context.getBlockPos());
+		}
+
 		ViewableWorld world = context.getWorld();
 		BlockPos pos = context.getBlockPos();
 		FluidState fluid = context.getWorld().getFluidState(context.getBlockPos());
@@ -362,9 +385,7 @@ public class SmallLogBlock extends Block implements Waterloggable {
 		return false;
 	}
 
-	@Override
-	@SuppressWarnings("deprecation")
-	public BlockState getStateForNeighborUpdate(BlockState state, Direction fromDirection, BlockState neighbor, IWorld world, BlockPos pos, BlockPos neighborPos) {
+	public BlockState getNeighborUpdateState(BlockState state, Direction fromDirection, BlockState neighbor, IWorld world, BlockPos pos, BlockPos neighborPos) {
 		if (state.get(WATERLOGGED)) {
 			world.getFluidTickScheduler().schedule(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
 		}

--- a/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
+++ b/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
@@ -307,7 +307,7 @@ public class SmallLogBlock extends Block implements Waterloggable {
 	public BlockState getPlacementState(ItemPlacementContext context) {
 
 		if (context.getPlayer() == null) {
-			return context.getWorld().getBlockState(context.getBlockPos());
+			return this.getDefaultState();
 		}
 
 		ViewableWorld world = context.getWorld();

--- a/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
+++ b/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
@@ -307,7 +307,7 @@ public class SmallLogBlock extends Block implements Waterloggable {
 	public BlockState getPlacementState(ItemPlacementContext context) {
 
 		if (context.getPlayer() == null) {
-			return this.getDefaultState();
+			return context.getWorld().getBlockState(context.getBlockPos()).getBlock().equals(Blocks.WATER) ? this.getDefaultState().with(WATERLOGGED, true) : this.getDefaultState();
 		}
 
 		ViewableWorld world = context.getWorld();

--- a/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
+++ b/src/main/java/com/terraformersmc/terraform/block/SmallLogBlock.java
@@ -307,7 +307,7 @@ public class SmallLogBlock extends Block implements Waterloggable {
 	public BlockState getPlacementState(ItemPlacementContext context) {
 
 		if (context.getPlayer() == null) {
-			return context.getWorld().getBlockState(context.getBlockPos()).getBlock().equals(Blocks.WATER) ? this.getDefaultState().with(WATERLOGGED, true) : this.getDefaultState();
+			return context.getWorld().getFluidState(context.getBlockPos()).equals(WATERLOGGED) ? this.getDefaultState().with(WATERLOGGED, true) : this.getDefaultState();
 		}
 
 		ViewableWorld world = context.getWorld();


### PR DESCRIPTION
What this does is it simply makes it so that when a tree feature is generated the small log blocks can be made to generate adjacent branches and not updated when a neighbor state changes.

When a player places a small log block it performs as it did previously and other features that use a fixBlockStates method before won't be broken or changed in anyways because the log blocks are iterated over after they're already placed next to one another.