### PR TITLE
Fix farmland not always reverting back to custom dirt

### DIFF
--- a/terraform-dirt-api-v1/build.gradle
+++ b/terraform-dirt-api-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "terraform-dirt-api-v1"
-version = formatVersion(project, "1.0.0")
+version = formatVersion(project, "1.1.0")
 
 dependencies {
 	modImplementation fabricApi.module("fabric-tag-extensions-v0", project.fabric_version)

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/TerraformDirtRegistry.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/TerraformDirtRegistry.java
@@ -16,6 +16,7 @@ import net.minecraft.world.TestableWorld;
 public class TerraformDirtRegistry {
 	private static final List<DirtBlocks> TYPES = new ArrayList<>();
 	private static final Map<Block, DirtBlocks> BY_GRASS_BLOCK = new HashMap<>();
+	private static final Map<Block, DirtBlocks> BY_FARMLAND = new HashMap<>();
 
 	/**
 	 * Registers a new set of dirt blocks to Terraform.
@@ -36,6 +37,7 @@ public class TerraformDirtRegistry {
 
 		TYPES.add(blocks);
 		BY_GRASS_BLOCK.put(blocks.getGrassBlock(), blocks);
+		BY_FARMLAND.put(blocks.getFarmland(), blocks);
 
 		TillableBlockRegistry.add(blocks.getDirt(), blocks.getFarmland().getDefaultState());
 		TillableBlockRegistry.add(blocks.getGrassBlock(), blocks.getFarmland().getDefaultState());
@@ -61,5 +63,9 @@ public class TerraformDirtRegistry {
 
 	public static Optional<DirtBlocks> getByGrassBlock(Block grass) {
 		return Optional.ofNullable(BY_GRASS_BLOCK.get(grass));
+	}
+
+	public static Optional<DirtBlocks> getByFarmland(Block farmland) {
+		return Optional.ofNullable(BY_FARMLAND.get(farmland));
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/block/TerraformFarmlandBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/block/TerraformFarmlandBlock.java
@@ -18,69 +18,18 @@ import java.util.Random;
 
 /**
  * A custom farmland block for new farmland. Mixins are required to make hoes create these blocks and to allow seeds to be planted.
+ * @see com.terraformersmc.terraform.dirt.mixin.MixinFarmlandBlock
  */
 public class TerraformFarmlandBlock extends FarmlandBlock {
-	private Block trampled; //sets the block to revert to when trampled
-
+	/**
+	 * @deprecated the "trampled" block is no longer controlled by TerraformFarmlandBlock, use the other constructor.
+	 */
+	@Deprecated
 	public TerraformFarmlandBlock(Settings settings, Block trampled) {
 		super(settings);
-		this.setDefaultState(this.getStateManager().getDefaultState().with(MOISTURE, 0));
-		this.trampled = trampled;
 	}
 
-	@Override
-	public BlockState getPlacementState(ItemPlacementContext context) {
-		return !this.getDefaultState().canPlaceAt(context.getWorld(), context.getBlockPos()) ? trampled.getDefaultState() : this.getDefaultState();
-	}
-
-	@Override
-	public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-		if (!state.canPlaceAt(world, pos)) {
-			setToCustomDirt(state, world, pos);
-		} else {
-			int moisture = state.get(MOISTURE);
-			if (!isWaterNearby(world, pos) && !world.hasRain(pos.up())) {
-				if (moisture > 0) {
-					world.setBlockState(pos, state.with(MOISTURE, moisture - 1), 2);
-				} else if (!hasCrop(world, pos)) {
-					setToCustomDirt(state, world, pos);
-				}
-			} else if (moisture < 7) {
-				world.setBlockState(pos, state.with(MOISTURE, 7), 2);
-			}
-		}
-	}
-
-	public void setToCustomDirt(BlockState state, World world, BlockPos pos) {
-		world.setBlockState(pos, pushEntitiesUpBeforeBlockChange(state, trampled.getDefaultState(), world, pos));
-	}
-
-	private static boolean hasCrop(BlockView view, BlockPos pos) {
-		Block block = view.getBlockState(pos.up()).getBlock();
-		return block instanceof CropBlock || block instanceof StemBlock || block instanceof AttachedStemBlock;
-	}
-
-	@Override
-	public void onLandedUpon(World world, BlockPos pos, Entity entity, float height) {
-		if (!world.isClient && world.random.nextFloat() < height - 0.5F && entity instanceof LivingEntity && (entity instanceof PlayerEntity || world.getGameRules().getBoolean(GameRules.DO_MOB_GRIEFING)) && entity.getWidth() * entity.getWidth() * entity.getHeight() > 0.512F) {
-			setToCustomDirt(world.getBlockState(pos), world, pos);
-		}
-
-		entity.handleFallDamage(height, 1.0F);
-	}
-
-	private static boolean isWaterNearby(WorldView world, BlockPos pos) {
-		Iterator iterator = BlockPos.iterate(pos.add(-4, 0, -4), pos.add(4, 1, 4)).iterator();
-
-		BlockPos checkPos;
-		do {
-			if (!iterator.hasNext()) {
-				return false;
-			}
-
-			checkPos = (BlockPos) iterator.next();
-		} while (!world.getFluidState(checkPos).isIn(FluidTags.WATER));
-
-		return true;
+	public TerraformFarmlandBlock(Settings settings) {
+		super(settings);
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFarmlandBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFarmlandBlock.java
@@ -1,0 +1,39 @@
+package com.terraformersmc.terraform.dirt.mixin;
+
+import com.terraformersmc.terraform.dirt.TerraformDirtRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.FarmlandBlock;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@Mixin(FarmlandBlock.class)
+public class MixinFarmlandBlock {
+	@Inject(method = "getPlacementState(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/block/BlockState;",
+	        at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;DIRT:Lnet/minecraft/block/Block;"),
+	        cancellable = true)
+	private void terraform$setCustomDirtInBlockPlacement(ItemPlacementContext context, CallbackInfoReturnable<BlockState> cir) {
+		// If this is custom farmland, make sure that we don't set back to vanilla dirt
+		TerraformDirtRegistry.getByFarmland((Block) (Object) this).ifPresent(blocks -> {
+			cir.setReturnValue(blocks.getDirt().getDefaultState());
+		});
+	}
+
+	@Inject(method = "setToDirt(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
+	        at = @At("HEAD"), cancellable = true)
+	private static void terraform$setCustomDirt(BlockState state, World world, BlockPos pos, CallbackInfo ci) {
+		// If this is custom farmland, make sure that we don't set back to vanilla dirt
+		TerraformDirtRegistry.getByFarmland(state.getBlock()).ifPresent(blocks -> {
+			world.setBlockState(pos, Block.pushEntitiesUpBeforeBlockChange(state, blocks.getDirt().getDefaultState(), world, pos));
+
+			ci.cancel();
+		});
+	}
+}

--- a/terraform-dirt-api-v1/src/main/resources/mixins.terraform-dirt.json
+++ b/terraform-dirt-api-v1/src/main/resources/mixins.terraform-dirt.json
@@ -7,6 +7,7 @@
 	"MixinAnimalEntity",
 	"MixinCropBlock",
 	"MixinEatGrassGoal",
+	"MixinFarmlandBlock",
 	"MixinFeature",
 	"MixinPlantBlock",
 	"MixinPlantingOnFarmland",


### PR DESCRIPTION
This replaces most of the code in TerraformFarmlandBlock with a simple targeted mixin. This means we have to copy way less vanilla code, and can avoid missing all of the references to `setToDirt` as well.

This will enable us to fix https://github.com/TerraformersMC/Terrestria/issues/209