### PR TITLE
fix https://github.com/TerraformersMC/Terraform/issues/42

### DIFF
--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignBlockEntityRenderer.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignBlockEntityRenderer.java
@@ -7,19 +7,18 @@ import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.client.render.block.entity.SignBlockEntityRenderer;
 import net.minecraft.client.util.SpriteIdentifier;
-import net.minecraft.util.SignType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(SignBlockEntityRenderer.class)
 @Environment(EnvType.CLIENT)
 public class MixinSignBlockEntityRenderer {
-	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/util/SignType;)Lnet/minecraft/client/util/SpriteIdentifier;"))
-	private SpriteIdentifier getSignTextureId(SignType signType, SignBlockEntity signBlockEntity) {
+	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/util/SignType;)Lnet/minecraft/client/util/SpriteIdentifier;"))
+	private SpriteIdentifier getSignTextureId(SpriteIdentifier spriteIdentifier, SignBlockEntity signBlockEntity) {
 		if (signBlockEntity.getCachedState().getBlock() instanceof TerraformSign) {
 			return new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, ((TerraformSign) signBlockEntity.getCachedState().getBlock()).getTexture());
 		}
-		return TexturedRenderLayers.getSignTextureId(signType);
+		return spriteIdentifier;
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
@@ -7,12 +7,11 @@ import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.client.gui.screen.ingame.SignEditScreen;
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.client.util.SpriteIdentifier;
-import net.minecraft.util.SignType;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(SignEditScreen.class)
 @Environment(EnvType.CLIENT)
@@ -21,11 +20,11 @@ public class MixinSignEditScreen {
 	@Final
 	private SignBlockEntity sign;
 	
-	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/util/SignType;)Lnet/minecraft/client/util/SpriteIdentifier;"))
-	private SpriteIdentifier getSignTextureId(SignType signType) {
+	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/util/SignType;)Lnet/minecraft/client/util/SpriteIdentifier;"))
+	private SpriteIdentifier getSignTextureId(SpriteIdentifier spriteIdentifier) {
 		if (sign.getCachedState().getBlock() instanceof TerraformSign) {
 			return new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, ((TerraformSign) sign.getCachedState().getBlock()).getTexture());
 		}
-		return TexturedRenderLayers.getSignTextureId(signType);
+		return spriteIdentifier;
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
@@ -4,21 +4,27 @@ import com.terraformersmc.terraform.sign.TerraformSign;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.gui.screen.ingame.SignEditScreen;
 import net.minecraft.client.render.TexturedRenderLayers;
-import net.minecraft.client.render.block.entity.SignBlockEntityRenderer;
 import net.minecraft.client.util.SpriteIdentifier;
 import net.minecraft.util.SignType;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(SignBlockEntityRenderer.class)
+@Mixin(SignEditScreen.class)
 @Environment(EnvType.CLIENT)
-public class MixinSignBlockEntityRenderer {
+public class MixinSignEditScreen {
+	@Shadow
+	@Final
+	private SignBlockEntity sign;
+	
 	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/util/SignType;)Lnet/minecraft/client/util/SpriteIdentifier;"))
-	private SpriteIdentifier getSignTextureId(SignType signType, SignBlockEntity signBlockEntity) {
-		if (signBlockEntity.getCachedState().getBlock() instanceof TerraformSign) {
-			return new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, ((TerraformSign) signBlockEntity.getCachedState().getBlock()).getTexture());
+	private SpriteIdentifier getSignTextureId(SignType signType) {
+		if (sign.getCachedState().getBlock() instanceof TerraformSign) {
+			return new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, ((TerraformSign) sign.getCachedState().getBlock()).getTexture());
 		}
 		return TexturedRenderLayers.getSignTextureId(signType);
 	}

--- a/terraform-wood-api-v1/src/main/resources/mixins.terraform-signs.json
+++ b/terraform-wood-api-v1/src/main/resources/mixins.terraform-signs.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_16",
   "client": [
     "MixinSignBlockEntityRenderer",
+    "MixinSignEditScreen",
     "MixinTexturedRenderLayers"
   ],
   "mixins": [


### PR DESCRIPTION
Tested using a custom build of Bewitchment, Terraform signs no longer render as Oak, and instead what they are supposed to be.

![2021-07-29_20 54 42](https://user-images.githubusercontent.com/45156123/127588169-aa644124-cc39-4c88-92ad-03f7fa44e8db.png)
