### PR TITLE
Proposed update to wood API:

### DIFF
--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
@@ -2,16 +2,14 @@ package com.terraformersmc.terraform.wood.block;
 
 import java.util.function.Supplier;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.MapColor;
-import net.minecraft.block.PillarBlock;
+import net.minecraft.block.*;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.MiningToolItem;
+import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.state.StateManager;
@@ -33,10 +31,28 @@ public class QuarterLogBlock extends PillarBlock {
 	public static final EnumProperty<BarkSide> BARK_SIDE = EnumProperty.of("bark_side", BarkSide.class);
 	private final Supplier<Block> stripped;
 
-	public QuarterLogBlock(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+	public QuarterLogBlock(Supplier<Block> stripped, Block.Settings settings) {
 		super(settings);
 
 		this.stripped = stripped;
+	}
+
+	@Deprecated
+	public QuarterLogBlock(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+		this(stripped, settings);
+	}
+
+	public QuarterLogBlock of(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+		return new QuarterLogBlock(stripped, settings.mapColor(color));
+	}
+
+	public QuarterLogBlock of(Supplier<Block> stripped, MapColor top, MapColor side) {
+		return new QuarterLogBlock(stripped,
+				Block.Settings.of(
+						Material.WOOD,
+						(state) -> Direction.Axis.Y.equals(state.get(PillarBlock.AXIS)) ? top : side
+				).strength(2.0F).sounds(BlockSoundGroup.WOOD)
+		);
 	}
 
 	@Override
@@ -64,21 +80,19 @@ public class QuarterLogBlock extends PillarBlock {
 	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
 		ItemStack heldStack = player.getEquippedStack(hand == Hand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
 
-		if(heldStack.isEmpty()) {
+		if (heldStack.isEmpty()) {
 			return ActionResult.FAIL;
 		}
 
 		Item held = heldStack.getItem();
-		if(!(held instanceof MiningToolItem)) {
+		if (!(held instanceof MiningToolItem tool)) {
 			return ActionResult.FAIL;
 		}
 
-		MiningToolItem tool = (MiningToolItem) held;
-
-		if(stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
+		if (stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
 			world.playSound(player, pos, SoundEvents.ITEM_AXE_STRIP, SoundCategory.BLOCKS, 1.0F, 1.0F);
 
-			if(!world.isClient) {
+			if (!world.isClient) {
 				BlockState target = stripped.get().getDefaultState()
 						.with(QuarterLogBlock.AXIS, state.get(QuarterLogBlock.AXIS))
 						.with(QuarterLogBlock.BARK_SIDE, state.get(QuarterLogBlock.BARK_SIDE));

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/StrippableLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/StrippableLogBlock.java
@@ -2,51 +2,66 @@ package com.terraformersmc.terraform.wood.block;
 
 import java.util.function.Supplier;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.MapColor;
-import net.minecraft.block.PillarBlock;
+import net.minecraft.block.*;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.MiningToolItem;
+import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 public class StrippableLogBlock extends PillarBlock {
-	private Supplier<Block> stripped;
+	private final Supplier<Block> stripped;
 
-	public StrippableLogBlock(Supplier<Block> stripped, MapColor top, Settings settings) {
+	public StrippableLogBlock(Supplier<Block> stripped, Settings settings) {
 		super(settings);
 
 		this.stripped = stripped;
+	}
+
+	@Deprecated
+	public StrippableLogBlock(Supplier<Block> stripped, MapColor color, Settings settings) {
+		this(stripped, settings);
+	}
+
+	public StrippableLogBlock of(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+		return new StrippableLogBlock(stripped, settings.mapColor(color));
+	}
+
+	public StrippableLogBlock of(Supplier<Block> stripped, MapColor top, MapColor side) {
+		return new StrippableLogBlock(stripped,
+			Block.Settings.of(
+				Material.WOOD,
+				(state) -> Direction.Axis.Y.equals(state.get(PillarBlock.AXIS)) ? top : side
+			).strength(2.0F).sounds(BlockSoundGroup.WOOD)
+		);
 	}
 
 	@Override
 	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
 		ItemStack heldStack = player.getEquippedStack(hand == Hand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
 
-		if(heldStack.isEmpty()) {
+		if (heldStack.isEmpty()) {
 			return ActionResult.FAIL;
 		}
 
 		Item held = heldStack.getItem();
-		if(!(held instanceof MiningToolItem)) {
+		if (!(held instanceof MiningToolItem tool)) {
 			return ActionResult.FAIL;
 		}
 
-		MiningToolItem tool = (MiningToolItem) held;
-
-		if(stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
+		if (stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
 			world.playSound(player, pos, SoundEvents.ITEM_AXE_STRIP, SoundCategory.BLOCKS, 1.0F, 1.0F);
 
-			if(!world.isClient) {
+			if (!world.isClient) {
 				BlockState target = stripped.get().getDefaultState().with(PillarBlock.AXIS, state.get(PillarBlock.AXIS));
 
 				world.setBlockState(pos, target);


### PR DESCRIPTION
I finally stopped ignoring the following comment in TraverseBlocks:

```java
	// Todo: fix when Fabric API supports `of(Material material, Function<BlockState, MapColor> mapColor)`
	private static PillarBlock createLog(MapColor topColor, MapColor sideColor) {
		return new PillarBlock(FabricBlockSettings.copyOf(Blocks.OAK_LOG).strength(2.0F).sounds(BlockSoundGroup.WOOD));
	}
```

Fabric API now does support that pattern, and/but/also the same factory can be accessed directly via Block.Settings.

After I updated Traverse to follow the change and confirmed it works for stripped logs, I realized it does not work for non-stripped logs because they are created via Terraform API's StrippableLogBlock::new method.  I am proposing to retire the ctor with an unused MapColor arg in favor of a couple new static factory methods.

Changes:
- Track Minecraft changes in AbstractBlock.Settings.
- Add static factory methods for strippable logs classes.
- Deprecate log ctors with unused MapColor arguments.