### PR TITLE
Make boat item parameters ItemConvertibles

### DIFF
--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/api/TerraformBoatType.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/api/TerraformBoatType.java
@@ -4,7 +4,7 @@ import com.terraformersmc.terraform.boat.impl.TerraformBoatTypeImpl;
 import com.terraformersmc.terraform.boat.impl.entity.TerraformBoatEntity;
 import com.terraformersmc.terraform.boat.impl.entity.TerraformChestBoatEntity;
 
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemConvertible;
 
 /**
  * An interface representing a Terraform boat.
@@ -16,19 +16,19 @@ public interface TerraformBoatType {
 	boolean isRaft();
 
 	/**
-	 * {@return the {@linkplain net.minecraft.entity.vehicle.BoatEntity#getPickBlockStack() pick stack} and {@linkplain Item item} dropped when the {@linkplain TerraformBoatEntity boat entity} is broken}
+	 * {@return the {@linkplain net.minecraft.entity.vehicle.BoatEntity#getPickBlockStack() pick stack} and {@linkplain ItemConvertible item} dropped when the {@linkplain TerraformBoatEntity boat entity} is broken}
 	 */
-	Item getItem();
+	ItemConvertible getItem();
 
 	/**
-	 * {@return the {@linkplain net.minecraft.entity.vehicle.BoatEntity#getPickBlockStack() pick stack} and {@linkplain Item item} dropped when the {@linkplain TerraformChestBoatEntity chest boat entity} is broken}
+	 * {@return the {@linkplain net.minecraft.entity.vehicle.BoatEntity#getPickBlockStack() pick stack} and {@linkplain ItemConvertible item} dropped when the {@linkplain TerraformChestBoatEntity chest boat entity} is broken}
 	 */
-	Item getChestItem();
+	ItemConvertible getChestItem();
 
 	/**
-	 * {@return the planks {@linkplain Item item} dropped when the {@linkplain TerraformBoatEntity boat entity} or {@linkplain TerraformChestBoatEntity chest boat entity} is destroyed into planks and sticks}
+	 * {@return the planks {@linkplain ItemConvertible item} dropped when the {@linkplain TerraformBoatEntity boat entity} or {@linkplain TerraformChestBoatEntity chest boat entity} is destroyed into planks and sticks}
 	 */
-	Item getPlanks();
+	ItemConvertible getPlanks();
 
 	/**
 	 * A builder for {@linkplain TerraformBoatType Terraform boat types}.
@@ -43,9 +43,9 @@ public interface TerraformBoatType {
 	 */
 	public static class Builder {
 		private boolean raft;
-		private Item item;
-		private Item chestItem;
-		private Item planks;
+		private ItemConvertible item;
+		private ItemConvertible chestItem;
+		private ItemConvertible planks;
 
 		public TerraformBoatType build() {
 			return new TerraformBoatTypeImpl(this.raft, this.item, this.chestItem, this.planks);
@@ -62,7 +62,7 @@ public interface TerraformBoatType {
 		/**
 		 * @see TerraformBoatType#getItem
 		 */
-		public Builder item(Item item) {
+		public Builder item(ItemConvertible item) {
 			this.item = item;
 			return this;
 		}
@@ -70,7 +70,7 @@ public interface TerraformBoatType {
 		/**
 		 * @see TerraformBoatType#getChestItem
 		 */
-		public Builder chestItem(Item chestItem) {
+		public Builder chestItem(ItemConvertible chestItem) {
 			this.chestItem = chestItem;
 			return this;
 		}
@@ -78,7 +78,7 @@ public interface TerraformBoatType {
 		/**
 		 * @see TerraformBoatType#getPlanks
 		 */
-		public Builder planks(Item planks) {
+		public Builder planks(ItemConvertible planks) {
 			this.planks = planks;
 			return this;
 		}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/TerraformBoatTypeImpl.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/TerraformBoatTypeImpl.java
@@ -2,18 +2,18 @@ package com.terraformersmc.terraform.boat.impl;
 
 import com.terraformersmc.terraform.boat.api.TerraformBoatType;
 
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemConvertible;
 
 /**
  * A simple implementation of {@link TerraformBoatType}.
  */
 public class TerraformBoatTypeImpl implements TerraformBoatType {
 	private final boolean raft;
-	private final Item item;
-	private final Item chestItem;
-	private final Item planks;
+	private final ItemConvertible item;
+	private final ItemConvertible chestItem;
+	private final ItemConvertible planks;
 
-	public TerraformBoatTypeImpl(boolean raft, Item item, Item chestItem, Item planks) {
+	public TerraformBoatTypeImpl(boolean raft, ItemConvertible item, ItemConvertible chestItem, ItemConvertible planks) {
 		this.raft = raft;
 		this.item = item;
 		this.chestItem = chestItem;
@@ -26,17 +26,17 @@ public class TerraformBoatTypeImpl implements TerraformBoatType {
 	}
 
 	@Override
-	public Item getItem() {
+	public ItemConvertible getItem() {
 		return this.item;
 	}
 
 	@Override
-	public Item getChestItem() {
+	public ItemConvertible getChestItem() {
 		return this.chestItem;
 	}
 
 	@Override
-	public Item getPlanks() {
+	public ItemConvertible getPlanks() {
 		return this.planks;
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/entity/TerraformBoatEntity.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/entity/TerraformBoatEntity.java
@@ -55,7 +55,7 @@ public class TerraformBoatEntity extends BoatEntity implements TerraformBoatHold
 
 	@Override
 	public Item asItem() {
-		return this.getTerraformBoat().getItem();
+		return this.getTerraformBoat().getItem().asItem();
 	}
 
 	@Override

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/entity/TerraformChestBoatEntity.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/entity/TerraformChestBoatEntity.java
@@ -56,7 +56,7 @@ public class TerraformChestBoatEntity extends ChestBoatEntity implements Terrafo
 
 	@Override
 	public Item asItem() {
-		return this.getTerraformBoat().getChestItem();
+		return this.getTerraformBoat().getChestItem().asItem();
 	}
 
 	@Override

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntity.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntity.java
@@ -4,7 +4,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import com.terraformersmc.terraform.boat.api.TerraformBoatType;
 import com.terraformersmc.terraform.boat.impl.entity.TerraformBoatHolder;
 
 import net.minecraft.entity.vehicle.BoatEntity;
@@ -14,9 +13,8 @@ import net.minecraft.item.ItemConvertible;
 public class MixinBoatEntity {
 	@ModifyArg(method = "fall(DZLnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V", index = 0, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/BoatEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", ordinal = 0))
 	private ItemConvertible replaceTerraformPlanksDropItem(ItemConvertible original) {
-		if ((Object) this instanceof TerraformBoatHolder) {
-			TerraformBoatType boat = ((TerraformBoatHolder) (Object) this).getTerraformBoat();
-			return boat.getPlanks();
+		if (this instanceof TerraformBoatHolder boatHolder) {
+			return boatHolder.getTerraformBoat().getPlanks();
 		}
 
 		return original;


### PR DESCRIPTION
This PR changes the parameters `item`, `chestItem `and `planks` to be instances of `ItemConvertible` instead of `Item` to prevent from a very specific crash:

Instances of `TerraformBoatType` that are constructed before its parameters are registered will cause a crash when opening the creative inventory. To be even more precise, I have encountered this issue by calling the `asItem()` method to pass a `Block` as a parameter for `planks` in my `TerraformBoatType` instance.

This PR also quickly reformats an `instanceof` and cast to its Java 14 form pattern matching in `MixinBoatEntity`, which decrements the number of imports by 1. 