### PR TITLE
Terraform wood API updates and bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 maven_group=com.terraformersmc.terraform-api
 version=6.0.0-beta.2
 
-minecraft_version=1.19.4-pre3
-yarn_mappings=1.19.4-pre3+build.1
-loader_version=0.14.14
-fabric_version=0.75.2+1.19.4
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.17
+fabric_version=0.75.3+1.19.4

--- a/terraform-wood-api-v1/build.gradle
+++ b/terraform-wood-api-v1/build.gradle
@@ -1,8 +1,9 @@
 archivesBaseName = "terraform-wood-api-v1"
 
 dependencies {
-	modImplementation fabricApi.module("fabric-object-builder-api-v1", project.fabric_version)
+	modImplementation fabricApi.module("fabric-content-registries-v0", project.fabric_version)
 	modImplementation fabricApi.module("fabric-networking-api-v1", project.fabric_version)
+	modImplementation fabricApi.module("fabric-object-builder-api-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-registry-sync-v0", project.fabric_version)
 	modImplementation fabricApi.module("fabric-rendering-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-resource-loader-v0", project.fabric_version)

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/block/ExtendedLeavesBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/block/ExtendedLeavesBlock.java
@@ -1,38 +1,34 @@
 package com.terraformersmc.terraform.leaves.block;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
+import net.minecraft.block.LeavesBlock;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
-import net.minecraft.state.property.BooleanProperty;
-import net.minecraft.state.property.IntProperty;
-import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
-import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
-import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 
 /**
  * A leaves block with extended range, permitting leaves to be as far as 13 blocks away from the tree rather than the
  * limit of 6 blocks imposed by vanilla leaves. It also does not block light at all.
+ *
+ * This class must override every LeavesBlock function that references (compiler inlined) MAX_DISTANCE.
+ * The DISTANCE_1_7 property used by LeavesBlock is globally overridden by our MixinProperties.
  */
-public class ExtendedLeavesBlock extends Block {
+public class ExtendedLeavesBlock extends LeavesBlock {
 	public static final int MAX_DISTANCE = 14;
-	public static final BooleanProperty PERSISTENT = Properties.PERSISTENT;
-	public static final IntProperty DISTANCE = IntProperty.of("distance", 1, MAX_DISTANCE);
 
-	public ExtendedLeavesBlock(Block.Settings settings) {
+	public ExtendedLeavesBlock(AbstractBlock.Settings settings) {
 		super(settings);
-		this.setDefaultState(this.getStateManager().getDefaultState().with(DISTANCE, MAX_DISTANCE).with(PERSISTENT, false));
+		this.setDefaultState(this.stateManager.getDefaultState().with(DISTANCE, MAX_DISTANCE).with(PERSISTENT, false).with(WATERLOGGED, false));
 	}
 
 	@Override
@@ -42,18 +38,21 @@ public class ExtendedLeavesBlock extends Block {
 
 	@Override
 	public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-		if (!state.get(PERSISTENT) && state.get(DISTANCE) == MAX_DISTANCE) {
-			dropStacks(state, world, pos);
+		if (this.shouldDecay(state)) {
+			ExtendedLeavesBlock.dropStacks(state, world, pos);
 			world.removeBlock(pos, false);
 		}
+	}
 
+	@Override
+	protected boolean shouldDecay(BlockState state) {
+		return !state.get(PERSISTENT) && state.get(DISTANCE) == MAX_DISTANCE;
 	}
 
 	@Override
 	public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-		world.setBlockState(pos, updateDistanceFromLogs(state, world, pos), 3);
+		world.setBlockState(pos, ExtendedLeavesBlock.updateDistanceFromLogs(state, world, pos), 3);
 	}
-
 
 	@Override
 	public int getOpacity(BlockState state, BlockView view, BlockPos pos) {
@@ -62,7 +61,11 @@ public class ExtendedLeavesBlock extends Block {
 
 	@Override
 	public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
-		int distance = getDistanceFromLog(neighborState) + 1;
+		if (state.get(WATERLOGGED)) {
+			world.scheduleFluidTick(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
+		}
+
+		int distance = ExtendedLeavesBlock.getDistanceFromLog(neighborState) + 1;
 		if (distance != 1 || state.get(DISTANCE) != distance) {
 			world.scheduleBlockTick(pos, this, 1);
 		}
@@ -76,7 +79,7 @@ public class ExtendedLeavesBlock extends Block {
 
 		for (Direction direction : Direction.values()) {
 			mutable.set(pos, direction);
-			distance = Math.min(distance, getDistanceFromLog(world.getBlockState(mutable)) + 1);
+			distance = Math.min(distance, ExtendedLeavesBlock.getDistanceFromLog(world.getBlockState(mutable)) + 1);
 			if (distance == 1) {
 				break;
 			}
@@ -88,35 +91,35 @@ public class ExtendedLeavesBlock extends Block {
 	private static int getDistanceFromLog(BlockState state) {
 		if (state.isIn(BlockTags.LOGS)) {
 			return 0;
-		} else {
-			return state.getBlock() instanceof ExtendedLeavesBlock ? state.get(DISTANCE) : MAX_DISTANCE;
 		}
+
+		Block block = state.getBlock();
+		if (block instanceof ExtendedLeavesBlock) {
+			return state.get(DISTANCE);
+		} else if (block instanceof LeavesBlock) {
+			int distance = state.get(DISTANCE);
+			return distance < LeavesBlock.MAX_DISTANCE ? distance : MAX_DISTANCE;
+		}
+
+		return MAX_DISTANCE;
 	}
 
-	@Environment(EnvType.CLIENT)
 	@Override
-	public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {
-		Blocks.OAK_LEAVES.randomDisplayTick(state, world, pos, random);
+	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+		builder.add(DISTANCE, PERSISTENT, WATERLOGGED);
+	}
+
+	@Override
+	public BlockState getPlacementState(ItemPlacementContext context) {
+		FluidState fluidState = context.getWorld().getFluidState(context.getBlockPos());
+		BlockState blockState = this.getDefaultState().with(PERSISTENT, true).with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+
+		return ExtendedLeavesBlock.updateDistanceFromLogs(blockState, context.getWorld(), context.getBlockPos());
 	}
 
 	@Override
 	public boolean isSideInvisible(BlockState state, BlockState neighborState, Direction offset) {
 		// OptiLeaves optimization: Cull faces with leaf block neighbors to reduce geometry in redwood forests
 		return neighborState.getBlock() instanceof ExtendedLeavesBlock;
-	}
-
-	@Override
-	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-		builder.add(DISTANCE, PERSISTENT);
-	}
-
-	@Override
-	public BlockState getPlacementState(ItemPlacementContext context) {
-		return updateDistanceFromLogs(this.getDefaultState().with(PERSISTENT, true), context.getWorld(), context.getBlockPos());
-	}
-
-	@Override
-	public VoxelShape getSidesShape(BlockState state, BlockView world, BlockPos pos) {
-		return VoxelShapes.empty();
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/block/ExtendedLeavesBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/block/ExtendedLeavesBlock.java
@@ -9,7 +9,6 @@ import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.state.StateManager;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.random.Random;
@@ -28,7 +27,11 @@ public class ExtendedLeavesBlock extends LeavesBlock {
 
 	public ExtendedLeavesBlock(AbstractBlock.Settings settings) {
 		super(settings);
-		this.setDefaultState(this.stateManager.getDefaultState().with(DISTANCE, MAX_DISTANCE).with(PERSISTENT, false).with(WATERLOGGED, false));
+
+		this.setDefaultState(this.stateManager.getDefaultState()
+				.with(DISTANCE, MAX_DISTANCE)
+				.with(PERSISTENT, false)
+				.with(WATERLOGGED, false));
 	}
 
 	@Override
@@ -102,11 +105,6 @@ public class ExtendedLeavesBlock extends LeavesBlock {
 		}
 
 		return MAX_DISTANCE;
-	}
-
-	@Override
-	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-		builder.add(DISTANCE, PERSISTENT, WATERLOGGED);
 	}
 
 	@Override

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/mixin/MixinProperties.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/mixin/MixinProperties.java
@@ -1,0 +1,24 @@
+package com.terraformersmc.terraform.leaves.mixin;
+
+import net.minecraft.state.property.IntProperty;
+import net.minecraft.state.property.Properties;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(Properties.class)
+public class MixinProperties {
+	/*
+	 * Inject our larger "distance" property [1,14] to replace vanilla's [1,7].
+	 * This allows leaves to extend up to 13 blocks from a log instead of 6.
+	 *
+	 * (The logic implementing the limit is based on the hard-coded MAX_DISTANCE
+	 * constant in LeavesBlock, so vanilla leaf behavior is unchanged by this.)
+	 */
+	@Shadow
+	@Final
+	@Mutable
+	@SuppressWarnings("unused")
+	public static IntProperty DISTANCE_1_7 = IntProperty.of("distance", 1, 14);
+}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/BareSmallLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/BareSmallLogBlock.java
@@ -44,20 +44,22 @@ public class BareSmallLogBlock extends Block implements Waterloggable {
 	public static final BooleanProperty WEST = Properties.WEST;
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
-	private static final int UP_MASK = 1 << Direction.UP.ordinal();
-	private static final int DOWN_MASK = 1 << Direction.DOWN.ordinal();
-	private static final int NORTH_MASK = 1 << Direction.NORTH.ordinal();
-	private static final int EAST_MASK = 1 << Direction.EAST.ordinal();
-	private static final int SOUTH_MASK = 1 << Direction.SOUTH.ordinal();
-	private static final int WEST_MASK = 1 << Direction.WEST.ordinal();
+	protected static final int UP_MASK = 1 << Direction.UP.ordinal();
+	protected static final int DOWN_MASK = 1 << Direction.DOWN.ordinal();
+	protected static final int NORTH_MASK = 1 << Direction.NORTH.ordinal();
+	protected static final int EAST_MASK = 1 << Direction.EAST.ordinal();
+	protected static final int SOUTH_MASK = 1 << Direction.SOUTH.ordinal();
+	protected static final int WEST_MASK = 1 << Direction.WEST.ordinal();
+
+	protected final int LOG_RADIUS = 5;
 
 	protected final VoxelShape[] collisionShapes;
 	protected final VoxelShape[] boundingShapes;
-	private final Object2IntMap<BlockState> SHAPE_INDEX_CACHE = new Object2IntOpenHashMap<>();
+	protected final Object2IntMap<BlockState> SHAPE_INDEX_CACHE = new Object2IntOpenHashMap<>();
 
 	public BareSmallLogBlock(Block.Settings settings) {
 		super(settings);
-		this.setDefaultState(this.getStateManager().getDefaultState()
+		this.setDefaultState(this.stateManager.getDefaultState()
 				.with(AXIS, Direction.Axis.Y)
 				.with(UP, false)
 				.with(DOWN, false)
@@ -68,8 +70,8 @@ public class BareSmallLogBlock extends Block implements Waterloggable {
 				.with(WATERLOGGED, false)
 		);
 
-		this.collisionShapes = this.createShapes(5);
-		this.boundingShapes = this.createShapes(5);
+		this.collisionShapes = this.createShapes(LOG_RADIUS);
+		this.boundingShapes = this.createShapes(LOG_RADIUS);
 	}
 
 	/**
@@ -118,12 +120,12 @@ public class BareSmallLogBlock extends Block implements Waterloggable {
 		return new BareSmallLogBlock(
 				Block.Settings.of(
 						Material.WOOD,
-						(state) -> Direction.Axis.Y.equals(state.get(PillarBlock.AXIS)) ? wood : bark
+						(state) -> state.get(UP) ? wood : bark
 				).strength(2.0F).sounds(BlockSoundGroup.WOOD)
 		);
 	}
 
-	private int getShapeIndex(BlockState requested) {
+	protected int getShapeIndex(BlockState requested) {
 		return this.SHAPE_INDEX_CACHE.computeIntIfAbsent(requested, state -> {
 			int mask = 0;
 
@@ -354,5 +356,23 @@ public class BareSmallLogBlock extends Block implements Waterloggable {
 	@Override
 	public VoxelShape getCollisionShape(BlockState state, BlockView view, BlockPos pos, ShapeContext context) {
 		return this.collisionShapes[this.getShapeIndex(state)];
+	}
+
+	/**
+	 * You can call this method on Terraformers API small logs to get the trunk radius.
+	 * The trunk will occupy 2*getTrunkRadius() centered in the block.
+	 *
+	 * <pre>{@code
+	 *     int trunkRadius = 8;
+	 *     if (block instanceof BareSmallLogBlock smallLogBlock) {
+	 *         trunkRadius = smallLogBlock.getLogRadius();
+	 *     }
+	 * }</pre>
+	 *
+	 * @return The radius of the log
+	 */
+	@SuppressWarnings("unused")
+	public int getLogRadius() {
+		return LOG_RADIUS;
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
@@ -22,6 +22,10 @@ public class QuarterLogBlock extends PillarBlock {
 
 	public QuarterLogBlock(Block.Settings settings) {
 		super(settings);
+
+		this.setDefaultState(this.stateManager.getDefaultState()
+				.with(AXIS, Direction.Axis.Y)
+				.with(BARK_SIDE, BarkSide.NORTHEAST));
 	}
 
 	/**

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/QuarterLogBlock.java
@@ -2,28 +2,16 @@ package com.terraformersmc.terraform.wood.block;
 
 import java.util.function.Supplier;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.MapColor;
-import net.minecraft.block.PillarBlock;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
+import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import net.minecraft.block.*;
 import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.MiningToolItem;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
+import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.EnumProperty;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import net.minecraft.util.StringIdentifiable;
-import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
 
 /**
  * A log block that has 4 different corners that combine together to form a huge and continuous 2x2 log.
@@ -31,12 +19,74 @@ import net.minecraft.world.World;
  */
 public class QuarterLogBlock extends PillarBlock {
 	public static final EnumProperty<BarkSide> BARK_SIDE = EnumProperty.of("bark_side", BarkSide.class);
-	private final Supplier<Block> stripped;
 
-	public QuarterLogBlock(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+	public QuarterLogBlock(Block.Settings settings) {
 		super(settings);
+	}
 
-		this.stripped = stripped;
+	/**
+	 * <p>This constructor is deprecated in favor of using the new QuarterLogBlock.of() factories
+	 * and Fabric's StrippableBlockRegistry.</p>
+	 *
+	 * <pre>{@code
+	 *     logBlock = QuarterLogBlock.of(settings, color);
+	 *     strippedBlock = QuarterLogBlock.of(settings, color);
+	 *     StrippableBlockRegistry.register(logBlock, strippedBlock);
+	 * }</pre>
+	 *
+	 * @param stripped Supplier of default BlockState for stripped variant
+	 * @param color Ignored (never implemented)
+	 * @param settings Block Settings for log
+	 */
+	@Deprecated(forRemoval = true)
+	public QuarterLogBlock(Supplier<Block> stripped, MapColor color, Block.Settings settings) {
+		this(settings);
+
+		if (stripped != null) {
+			StrippableBlockRegistry.register(this, stripped.get());
+		}
+	}
+
+	/**
+	 * Factory to create a QuarterLogBlock with the provided settings and
+	 * the same map color on the top/bottom and sides.
+	 *
+	 * @param settings Block Settings for log
+	 * @param color Map color for all faces of log
+	 * @return New QuarterLogBlock
+	 */
+	public static QuarterLogBlock of(Block.Settings settings, MapColor color) {
+		return new QuarterLogBlock(settings.mapColor(color));
+	}
+
+	/**
+	 * Factory to create a QuarterLogBlock with default settings and
+	 * different map colors on the exposed wood versus the bark sides.
+	 *
+	 * @param wood Map color for non-bark faces of log
+	 * @param bark Map color for bark faces of log
+	 * @return New QuarterLogBlock
+	 */
+	public static QuarterLogBlock of(MapColor wood, MapColor bark) {
+		return new QuarterLogBlock(
+				Block.Settings.of(
+						Material.WOOD,
+						(state) ->
+							switch (state.get(PillarBlock.AXIS)) {
+								case Y -> wood;
+								case X ->
+									switch (state.get(QuarterLogBlock.BARK_SIDE)) {
+										case NORTHWEST, SOUTHWEST -> bark;
+										case NORTHEAST, SOUTHEAST -> wood;
+									};
+								case Z ->
+									switch (state.get(QuarterLogBlock.BARK_SIDE)) {
+										case SOUTHEAST, SOUTHWEST -> bark;
+										case NORTHEAST, NORTHWEST -> wood;
+									};
+							}
+				).strength(2.0F).sounds(BlockSoundGroup.WOOD)
+		);
 	}
 
 	@Override
@@ -58,40 +108,6 @@ public class QuarterLogBlock extends PillarBlock {
 		BarkSide side = BarkSide.fromHit(context.getSide().getAxis(), hitX, hitY, hitZ);
 
 		return super.getPlacementState(context).with(BARK_SIDE, side);
-	}
-
-	@Override
-	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-		ItemStack heldStack = player.getEquippedStack(hand == Hand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-
-		if(heldStack.isEmpty()) {
-			return ActionResult.FAIL;
-		}
-
-		Item held = heldStack.getItem();
-		if(!(held instanceof MiningToolItem)) {
-			return ActionResult.FAIL;
-		}
-
-		MiningToolItem tool = (MiningToolItem) held;
-
-		if(stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
-			world.playSound(player, pos, SoundEvents.ITEM_AXE_STRIP, SoundCategory.BLOCKS, 1.0F, 1.0F);
-
-			if(!world.isClient) {
-				BlockState target = stripped.get().getDefaultState()
-						.with(QuarterLogBlock.AXIS, state.get(QuarterLogBlock.AXIS))
-						.with(QuarterLogBlock.BARK_SIDE, state.get(QuarterLogBlock.BARK_SIDE));
-
-				world.setBlockState(pos, target);
-
-				heldStack.damage(1, player, consumedPlayer -> consumedPlayer.sendToolBreakStatus(hand));
-			}
-
-			return ActionResult.SUCCESS;
-		}
-
-		return ActionResult.SUCCESS;
 	}
 
 	/**

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/SmallLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/SmallLogBlock.java
@@ -1,7 +1,5 @@
 package com.terraformersmc.terraform.wood.block;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
@@ -37,25 +35,14 @@ import java.util.function.Supplier;
  * Used for things like the Sakura tree.
  */
 public class SmallLogBlock extends BareSmallLogBlock {
-
 	public static final BooleanProperty HAS_LEAVES = BooleanProperty.of("has_leaves");
-
-	private static final int UP_MASK = 1 << Direction.UP.ordinal();
-	private static final int DOWN_MASK = 1 << Direction.DOWN.ordinal();
-	private static final int NORTH_MASK = 1 << Direction.NORTH.ordinal();
-	private static final int EAST_MASK = 1 << Direction.EAST.ordinal();
-	private static final int SOUTH_MASK = 1 << Direction.SOUTH.ordinal();
-	private static final int WEST_MASK = 1 << Direction.WEST.ordinal();
-
-	protected final VoxelShape[] collisionShapes;
-	protected final VoxelShape[] boundingShapes;
-	private final Object2IntMap<BlockState> SHAPE_INDEX_CACHE = new Object2IntOpenHashMap<>();
 
 	private final Block leaves;
 
 	public SmallLogBlock(Block leaves, Settings settings) {
 		super(settings);
-		this.setDefaultState(this.getStateManager().getDefaultState()
+		this.setDefaultState(this.stateManager.getDefaultState()
+				.with(AXIS, Direction.Axis.Y)
 				.with(UP, false)
 				.with(DOWN, false)
 				.with(WEST, false)
@@ -66,8 +53,6 @@ public class SmallLogBlock extends BareSmallLogBlock {
 				.with(HAS_LEAVES, false)
 		);
 
-		this.collisionShapes = this.createShapes(5);
-		this.boundingShapes = this.createShapes(5);
 		this.leaves = leaves;
 	}
 
@@ -121,7 +106,7 @@ public class SmallLogBlock extends BareSmallLogBlock {
 				Block.Settings.of(
 						Material.WOOD,
 						(state) -> state.get(HAS_LEAVES) ? leaves.getDefaultMapColor() :
-								Direction.Axis.Y.equals(state.get(PillarBlock.AXIS)) ? wood : bark
+								state.get(UP) ? wood : bark
 				).strength(2.0F).sounds(BlockSoundGroup.WOOD)
 		);
 	}
@@ -204,7 +189,7 @@ public class SmallLogBlock extends BareSmallLogBlock {
 		builder.add(HAS_LEAVES);
 	}
 
-	private boolean shouldConnectTo(BlockState state, boolean solid, boolean leaves) {
+	protected boolean shouldConnectTo(BlockState state, boolean solid, boolean leaves) {
 		Block block = state.getBlock();
 
 		return solid || (!leaves && block instanceof LeavesBlock) || block instanceof BareSmallLogBlock;
@@ -233,39 +218,6 @@ public class SmallLogBlock extends BareSmallLogBlock {
 				.with(SOUTH, south)
 				.with(WEST, west);
 	}
-
-	private int getShapeIndex(BlockState requested) {
-		return this.SHAPE_INDEX_CACHE.computeIntIfAbsent(requested, state -> {
-			int mask = 0;
-
-			if (state.get(UP)) {
-				mask |= UP_MASK;
-			}
-
-			if (state.get(DOWN)) {
-				mask |= DOWN_MASK;
-			}
-
-			if (state.get(NORTH)) {
-				mask |= NORTH_MASK;
-			}
-
-			if (state.get(EAST)) {
-				mask |= EAST_MASK;
-			}
-
-			if (state.get(SOUTH)) {
-				mask |= SOUTH_MASK;
-			}
-
-			if (state.get(WEST)) {
-				mask |= WEST_MASK;
-			}
-
-			return mask;
-		});
-	}
-
 
 	@Override
 	public VoxelShape getOutlineShape(BlockState state, BlockView view, BlockPos pos, ShapeContext context) {

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/StrippableLogBlock.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/block/StrippableLogBlock.java
@@ -2,61 +2,63 @@ package com.terraformersmc.terraform.wood.block;
 
 import java.util.function.Supplier;
 
+import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.MapColor;
+import net.minecraft.block.Material;
 import net.minecraft.block.PillarBlock;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.MiningToolItem;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.util.math.Direction;
 
+@Deprecated(forRemoval = true)
 public class StrippableLogBlock extends PillarBlock {
-	private Supplier<Block> stripped;
-
+	/**
+	 * <p>This class is deprecated in favor of using PillarBlock and Fabric's StrippableBlockRegistry.</p>
+	 *
+	 * <pre>{@code
+	 *     logBlock = new PillarBlock(settings);
+	 *     strippedBlock = new PillarBlock(settings);
+	 *     StrippableBlockRegistry.register(logBlock, strippedBlock);
+	 * }</pre>
+	 *
+	 * @param stripped Supplier of default BlockState for stripped variant
+	 * @param top Ignored (not implemented)
+	 * @param settings Block Settings for log 
+	 */
 	public StrippableLogBlock(Supplier<Block> stripped, MapColor top, Settings settings) {
 		super(settings);
 
-		this.stripped = stripped;
+		if (stripped != null) {
+			StrippableBlockRegistry.register(this, stripped.get());
+		}
 	}
 
-	@Override
-	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-		ItemStack heldStack = player.getEquippedStack(hand == Hand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
+	/**
+	 * Factory to create a PillarBlock with the provided settings and
+	 * the same map color on the top/bottom and sides.
+	 *
+	 * @param settings Block Settings for log
+	 * @param color Map color for all faces of log
+	 * @return New PillarBlock
+	 */
+	public static PillarBlock of(Block.Settings settings, MapColor color) {
+		return new PillarBlock(settings.mapColor(color));
+	}
 
-		if(heldStack.isEmpty()) {
-			return ActionResult.FAIL;
-		}
-
-		Item held = heldStack.getItem();
-		if(!(held instanceof MiningToolItem)) {
-			return ActionResult.FAIL;
-		}
-
-		MiningToolItem tool = (MiningToolItem) held;
-
-		if(stripped != null && (tool.getMiningSpeedMultiplier(heldStack, state) > 1.0F)) {
-			world.playSound(player, pos, SoundEvents.ITEM_AXE_STRIP, SoundCategory.BLOCKS, 1.0F, 1.0F);
-
-			if(!world.isClient) {
-				BlockState target = stripped.get().getDefaultState().with(PillarBlock.AXIS, state.get(PillarBlock.AXIS));
-
-				world.setBlockState(pos, target);
-
-				heldStack.damage(1, player, consumedPlayer -> consumedPlayer.sendToolBreakStatus(hand));
-			}
-
-			return ActionResult.SUCCESS;
-		}
-
-		return ActionResult.FAIL;
+	/**
+	 * Factory to create a PillarBlock with default settings and
+	 * different map colors on the top/bottom versus the sides.
+	 *
+	 * @param wood Map color for non-bark faces of log (ends)
+	 * @param bark Map color for bark faces of log (sides)
+	 * @return New PillarBlock
+	 */
+	public static PillarBlock of(MapColor wood, MapColor bark) {
+		return new PillarBlock(
+				Block.Settings.of(
+						Material.WOOD,
+						(state) -> Direction.Axis.Y.equals(state.get(PillarBlock.AXIS)) ? wood : bark
+				).strength(2.0F).sounds(BlockSoundGroup.WOOD)
+		);
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/mixin/MixinAxeItem.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/wood/mixin/MixinAxeItem.java
@@ -1,0 +1,27 @@
+package com.terraformersmc.terraform.wood.mixin;
+
+import com.terraformersmc.terraform.wood.block.BareSmallLogBlock;
+import com.terraformersmc.terraform.wood.block.QuarterLogBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.AxeItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+
+@Mixin(AxeItem.class)
+public class MixinAxeItem {
+	@Inject(method = "getStrippedState", at = @At("TAIL"), cancellable = true)
+	private void terraform$getStrippedState(BlockState oldState, CallbackInfoReturnable<Optional<BlockState>> cir) {
+		cir.getReturnValue().ifPresent(newState -> {
+			Block newBlock = newState.getBlock();
+			// SmallLogBlock extends BareSmallLogBlock
+			if (newBlock instanceof BareSmallLogBlock || newBlock instanceof QuarterLogBlock) {
+				cir.setReturnValue(Optional.of(newBlock.getStateWithProperties(oldState)));
+			}
+		});
+	}
+}

--- a/terraform-wood-api-v1/src/main/resources/fabric.mod.json
+++ b/terraform-wood-api-v1/src/main/resources/fabric.mod.json
@@ -19,8 +19,9 @@
     "issues": "https://github.com/TerraformersMC/Terraform/issues"
   },
   "depends": {
-    "fabric-object-builder-api-v1": "*",
+    "fabric-content-registries-v0": "*",
     "fabric-networking-api-v1": "*",
+    "fabric-object-builder-api-v1": "*",
     "fabric-registry-sync-v0": "*",
     "fabric-rendering-v1": "*",
     "fabric-resource-loader-v0": "*"
@@ -34,7 +35,8 @@
     "SuperCoder79",
     "NeusFear",
     "Vaerian",
-    "NebelNidas"
+    "NebelNidas",
+    "gniftygnome"
   ],
   "description": "Adds an API for adding custom wood types",
   "custom": {
@@ -60,6 +62,7 @@
   "mixins": [
     "mixins.terraform-boats.json",
     "mixins.terraform-leaves.json",
-    "mixins.terraform-signs.json"
+    "mixins.terraform-signs.json",
+    "mixins.terraform-wood.json"
   ]
 }

--- a/terraform-wood-api-v1/src/main/resources/mixins.terraform-wood.json
+++ b/terraform-wood-api-v1/src/main/resources/mixins.terraform-wood.json
@@ -1,10 +1,9 @@
 {
   "required": true,
-  "package": "com.terraformersmc.terraform.leaves.mixin",
+  "package": "com.terraformersmc.terraform.wood.mixin",
   "compatibilityLevel": "JAVA_16",
   "client": [
-    "MixinProperties",
-    "MixinRenderLayers"
+    "MixinAxeItem"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
These changes should allow existing mod code to function without modification (except [^1]).  However, they are fairly large changes internally for all Terraform wood API log blocks and for ExtendedLeavesBlock.

- Update to 1.19.4 release
- Stripped quarter logs no longer play the axe use animation
- Sculk sensors react to stripping Terraformers' logs
- Redwood leaves are waterloggable (and other Terraform extended leaves)
- Extended leaves extend LeavesBlock for better mod compatibility

[^1]: Direct references to `ExtendedLeavesBlock.DISTANCE` are no longer safe.  Use `LeavesBlock.DISTANCE` instead.
