### PR TITLE
Update mixins and consolidate mixin code style.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ version=8.0.0
 minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.1
 loader_version=0.14.22
-fabric_version=0.89.0+1.20.2
+fabric_version=0.89.1+1.20.2
 
 mixinextras_version=0.2.0-rc.4

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/TerraformDirtRegistry.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/TerraformDirtRegistry.java
@@ -28,10 +28,11 @@ public class TerraformDirtRegistry {
 	 * else things will not work properly!</p>
 	 *
 	 * @param blocks the DirtBlocks to register with Terraform. Note that you are still responsible for registering the
-	 *               block instances with {@link net.minecraft.util.registry.Registry#BLOCK} yourself, this method does
+	 *               block instances with {@link net.minecraft.registry.Registries#BLOCK} yourself, this method does
 	 *               not do that for you.
 	 * @return the registered DirtBlocks instance for convenience
 	 */
+	@SuppressWarnings("unused")
 	public static DirtBlocks register(DirtBlocks blocks) {
 		Objects.requireNonNull(blocks);
 
@@ -46,12 +47,22 @@ public class TerraformDirtRegistry {
 		return blocks;
 	}
 
-	public static Optional<DirtBlocks> getFromWorld(TestableWorld world, BlockPos pos) {
+    /**
+     * Return the corresponding DirtBlocks if the Block at pos is any Terraform API dirt variant;
+	 * otherwise returns {@link Optional#empty()}.
+	 *
+	 * <p>If you are looking for only specific dirt variants, see
+	 * {@link TerraformDirtRegistry#getByGrassBlock(Block)} and
+	 * {@link TerraformDirtRegistry#getByFarmland(Block)}.</p>
+     */
+    public static Optional<DirtBlocks> getFromWorld(TestableWorld world, BlockPos pos) {
 		for (DirtBlocks blocks: TYPES) {
 			Predicate<BlockState> isDirtLike =
-					state -> state.getBlock() == blocks.getDirt() ||
-							state.getBlock() == blocks.getGrassBlock() ||
-							state.getBlock() == blocks.getPodzol();
+					state -> state.isOf(blocks.getDirt()) ||
+							state.isOf(blocks.getDirtPath()) ||
+							state.isOf(blocks.getFarmland()) ||
+							state.isOf(blocks.getGrassBlock()) ||
+							state.isOf(blocks.getPodzol());
 
 			if (world.testBlockState(pos, isDirtLike)) {
 				return Optional.of(blocks);

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/block/TerraformDirtPathBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/block/TerraformDirtPathBlock.java
@@ -1,23 +1,18 @@
 package com.terraformersmc.terraform.dirt.block;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.DirtPathBlock;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.random.Random;
 
 public class TerraformDirtPathBlock extends DirtPathBlock {
-	private Block dirt;
-
+	/**
+	 * @deprecated the "dirt" block is no longer used by TerraformDirtPathBlock, use the other constructor.
+	 */
+	@Deprecated
 	public TerraformDirtPathBlock(Block dirt, Settings settings) {
 		super(settings);
-
-		this.dirt = dirt;
 	}
 
-	@Override
-	public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-		world.setBlockState(pos, pushEntitiesUpBeforeBlockChange(state, dirt.getDefaultState(), world, pos));
+	public TerraformDirtPathBlock(Settings settings) {
+		super(settings);
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinAlterGroundTreeDecorator.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinAlterGroundTreeDecorator.java
@@ -18,9 +18,12 @@ import net.minecraft.world.gen.treedecorator.TreeDecorator;
 @Mixin(AlterGroundTreeDecorator.class)
 public class MixinAlterGroundTreeDecorator {
 	// prepareGroundColumn
-	@Inject(method = "setColumn(Lnet/minecraft/world/gen/treedecorator/TreeDecorator$Generator;Lnet/minecraft/util/math/BlockPos;)V", at = @At("HEAD"), cancellable = true)
-	private void terraform$allowCustomPodzolPlacement(TreeDecorator.Generator generator, BlockPos pos, CallbackInfo callback) {
-		for(int i = 2; i >= -3; --i) {
+	@Inject(method = "setColumn(Lnet/minecraft/world/gen/treedecorator/TreeDecorator$Generator;Lnet/minecraft/util/math/BlockPos;)V",
+			at = @At("HEAD"),
+			cancellable = true
+	)
+	private void terraformDirt$allowCustomPodzolPlacement(TreeDecorator.Generator generator, BlockPos pos, CallbackInfo ci) {
+		for (int i = 2; i >= -3; --i) {
 			BlockPos posUp = pos.up(i);
 
 			// Test if there's a custom soil block at this location
@@ -30,7 +33,7 @@ public class MixinAlterGroundTreeDecorator {
 				Block podzol = TerraformDirtRegistry.getFromWorld(generator.getWorld(), posUp).map(DirtBlocks::getPodzol).orElse(Blocks.PODZOL);
 
 				generator.replace(posUp, podzol.getDefaultState());
-				callback.cancel();
+				ci.cancel();
 				return;
 			}
 

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinAnimalEntity.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinAnimalEntity.java
@@ -1,24 +1,27 @@
 package com.terraformersmc.terraform.dirt.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.terraformersmc.terraform.dirt.TerraformDirtBlockTags;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.registry.tag.TagKey;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.passive.AnimalEntity;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.random.Random;
-import net.minecraft.world.WorldAccess;
 
 @Mixin(AnimalEntity.class)
 public class MixinAnimalEntity {
-	@Inject(method = "isValidNaturalSpawn(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/WorldAccess;Lnet/minecraft/entity/SpawnReason;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/random/Random;)Z", at = @At("HEAD"), cancellable = true)
-	private static void terraform$spawnOnCustomGrass(EntityType<? extends AnimalEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random, CallbackInfoReturnable<Boolean> cir) {
-		if(world.getBlockState(pos.down()).isIn(TerraformDirtBlockTags.GRASS_BLOCKS) && world.getBaseLightLevel(pos, 0) > 8) {
-			cir.setReturnValue(true);
+	@WrapOperation(
+			method = "isValidNaturalSpawn",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isIn(Lnet/minecraft/registry/tag/TagKey;)Z")
+	)
+	@SuppressWarnings("unused")
+	private static boolean terraformDirt$spawnOnCustomGrass(BlockState instance, TagKey<Block> grassTag, Operation<Boolean> operation) {
+		if (instance.isIn(TerraformDirtBlockTags.GRASS_BLOCKS)) {
+			return true;
 		}
+
+		return operation.call(instance, grassTag);
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinCropBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinCropBlock.java
@@ -14,7 +14,7 @@ public class MixinCropBlock {
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z")
 	)
 	@SuppressWarnings("unused")
-	private static boolean terraform$isOfFarmlandTag(BlockState instance, Block block, Operation<Boolean> original) {
+	private static boolean terraformDirt$isOfFarmlandTag(BlockState instance, Block block, Operation<Boolean> original) {
 		return original.call(instance, block) || (block == Blocks.FARMLAND && instance.isIn(TerraformDirtBlockTags.FARMLAND));
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinEatGrassGoal.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinEatGrassGoal.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(EatGrassGoal.class)
 public class MixinEatGrassGoal {
@@ -29,19 +30,24 @@ public class MixinEatGrassGoal {
 	@Final
 	private World world;
 
-	private static final String GRASS_BLOCK = "Lnet/minecraft/block/Blocks;GRASS_BLOCK:Lnet/minecraft/block/Block;";
-
-	@Inject(method = "canStart", at = @At(value = "FIELD", target = GRASS_BLOCK), cancellable = true)
-	private void terraform$startOnCustomGrass(CallbackInfoReturnable<Boolean> callbackInfo) {
+	@Inject(method = "canStart",
+			at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;GRASS_BLOCK:Lnet/minecraft/block/Block;"),
+			cancellable = true,
+			locals = LocalCapture.NO_CAPTURE
+	)
+	private void terraformDirt$startOnCustomGrass(CallbackInfoReturnable<Boolean> cir) {
 		BlockPos pos = this.mob.getBlockPos();
 
 		if (this.world.getBlockState(pos.down()).isIn(TerraformDirtBlockTags.GRASS_BLOCKS)) {
-			callbackInfo.setReturnValue(true);
+			cir.setReturnValue(true);
 		}
 	}
 
-	@Inject(method = "tick", at = @At(value = "FIELD", target = GRASS_BLOCK))
-	private void terraform$finishEatingOnCustomGrass(CallbackInfo info) {
+	@Inject(method = "tick",
+			at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;GRASS_BLOCK:Lnet/minecraft/block/Block;"),
+			locals = LocalCapture.NO_CAPTURE
+	)
+	private void terraformDirt$finishEatingOnCustomGrass(CallbackInfo ci) {
 		BlockPos downPos = this.mob.getBlockPos().down();
 		BlockState down = this.world.getBlockState(downPos);
 

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFarmlandBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFarmlandBlock.java
@@ -1,6 +1,7 @@
 package com.terraformersmc.terraform.dirt.mixin;
 
 import com.terraformersmc.terraform.dirt.TerraformDirtRegistry;
+import net.minecraft.world.event.GameEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,25 +15,39 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(FarmlandBlock.class)
-public class MixinFarmlandBlock {
-	@Inject(method = "getPlacementState(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/block/BlockState;",
+public class MixinFarmlandBlock extends Block {
+	public MixinFarmlandBlock(Settings settings) {
+		super(settings);
+	}
+
+	@Inject(method = "getPlacementState",
 	        at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;DIRT:Lnet/minecraft/block/Block;"),
-	        cancellable = true)
-	private void terraform$setCustomDirtInBlockPlacement(ItemPlacementContext context, CallbackInfoReturnable<BlockState> cir) {
+	        cancellable = true,
+			locals = LocalCapture.NO_CAPTURE
+	)
+	private void terraformDirt$setCustomDirtInBlockPlacement(ItemPlacementContext context, CallbackInfoReturnable<BlockState> cir) {
 		// If this is custom farmland, make sure that we don't set back to vanilla dirt
-		TerraformDirtRegistry.getByFarmland((Block) (Object) this).ifPresent(blocks -> {
+		TerraformDirtRegistry.getByFarmland(this).ifPresent(blocks -> {
 			cir.setReturnValue(blocks.getDirt().getDefaultState());
 		});
 	}
 
-	@Inject(method = "setToDirt(Lnet/minecraft/entity/Entity;Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
-	        at = @At("HEAD"), cancellable = true)
-	private static void terraform$setCustomDirt(Entity entity, BlockState state, World world, BlockPos pos, CallbackInfo ci) {
-		// If this is custom farmland, make sure that we don't set back to vanilla dirt
-		TerraformDirtRegistry.getByFarmland(state.getBlock()).ifPresent(blocks -> {
-			world.setBlockState(pos, Block.pushEntitiesUpBeforeBlockChange(state, blocks.getDirt().getDefaultState(), world, pos));
+	@Inject(method = "setToDirt",
+	        at = @At("HEAD"),
+			cancellable = true,
+			locals = LocalCapture.NO_CAPTURE
+	)
+	private static void terraformDirt$setCustomDirt(Entity entity, BlockState state, World world, BlockPos pos, CallbackInfo ci) {
+		// If this is custom dirt block, make sure that we don't set back to vanilla dirt.
+		// Note: as of 1.20.2, vanilla uses FarmlandBlock.setToDirt() for all trample-able blocks;
+		// we are not responsible for evaluating whether the block can be trampled, here.
+		TerraformDirtRegistry.getFromWorld(world, pos).ifPresent(blocks -> {
+			BlockState dirtState = FarmlandBlock.pushEntitiesUpBeforeBlockChange(state, blocks.getDirt().getDefaultState(), world, pos);
+			world.setBlockState(pos, dirtState);
+			world.emitGameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Emitter.of(entity, dirtState));
 
 			ci.cancel();
 		});

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFeature.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinFeature.java
@@ -11,9 +11,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Feature.class)
 public class MixinFeature {
 	@Inject(method = "isSoil(Lnet/minecraft/block/BlockState;)Z", at = @At("HEAD"), cancellable = true)
-	private static void terraform$includeCustomSoil(BlockState state, CallbackInfoReturnable<Boolean> callback) {
+	private static void terraformDirt$includeCustomSoil(BlockState state, CallbackInfoReturnable<Boolean> cir) {
 		if (state.isIn(TerraformDirtBlockTags.SOIL)) {
-			callback.setReturnValue(true);
+			cir.setReturnValue(true);
 		}
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantBlock.java
@@ -13,9 +13,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(PlantBlock.class)
 public class MixinPlantBlock {
 	@Inject(method = "canPlantOnTop", at = @At("HEAD"), cancellable = true)
-	protected void hookPlantOnTop(BlockState state, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> callback) {
-		if(state.isIn(TerraformDirtBlockTags.SOIL) || state.isIn(TerraformDirtBlockTags.FARMLAND)) {
-			callback.setReturnValue(true);
+	private void terraformDirt$hookPlantOnTop(BlockState state, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+		if (state.isIn(TerraformDirtBlockTags.SOIL) || state.isIn(TerraformDirtBlockTags.FARMLAND)) {
+			cir.setReturnValue(true);
 		}
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantingOnFarmland.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantingOnFarmland.java
@@ -1,23 +1,19 @@
 package com.terraformersmc.terraform.dirt.mixin;
 
 import com.terraformersmc.terraform.dirt.TerraformDirtBlockTags;
+import net.minecraft.block.*;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import net.minecraft.block.AttachedStemBlock;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.CropBlock;
-import net.minecraft.block.FarmlandBlock;
-import net.minecraft.block.StemBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 
-@Mixin({AttachedStemBlock.class, CropBlock.class, StemBlock.class})
+@Mixin({AttachedStemBlock.class, CropBlock.class, PitcherCropBlock.class, StemBlock.class})
 public class MixinPlantingOnFarmland {
 	@Inject(method = "canPlantOnTop", at = @At("HEAD"), cancellable = true)
-	private void terraformDirt$onCanPlantOnTop(BlockState floor, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+	private void terraformDirt$isOnFarmland(BlockState floor, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
 		if (floor.getBlock() instanceof FarmlandBlock && floor.isIn(TerraformDirtBlockTags.FARMLAND)) {
 			cir.setReturnValue(true);
 		}

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantingOnFarmland.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinPlantingOnFarmland.java
@@ -17,9 +17,9 @@ import net.minecraft.world.BlockView;
 @Mixin({AttachedStemBlock.class, CropBlock.class, StemBlock.class})
 public class MixinPlantingOnFarmland {
 	@Inject(method = "canPlantOnTop", at = @At("HEAD"), cancellable = true)
-	private void onCanPlantOnTop(BlockState floor, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> callback) {
+	private void terraformDirt$onCanPlantOnTop(BlockState floor, BlockView view, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
 		if (floor.getBlock() instanceof FarmlandBlock && floor.isIn(TerraformDirtBlockTags.FARMLAND)) {
-			callback.setReturnValue(true);
+			cir.setReturnValue(true);
 		}
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinRabbitEntity.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinRabbitEntity.java
@@ -17,15 +17,18 @@ import net.minecraft.world.WorldView;
 
 @Mixin(targets = "net.minecraft.entity.passive.RabbitEntity$EatCarrotCropGoal")
 public class MixinRabbitEntity {
-
 	@Shadow
 	private boolean wantsCarrots;
 
 	@Shadow
 	private boolean hasTarget;
 
-	@Inject(method = "isTargetPos(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;)Z", at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;FARMLAND:Lnet/minecraft/block/Block;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
-	private void onIsTargetBlock(WorldView world, BlockPos pos, CallbackInfoReturnable<Boolean> info, BlockState state) {
+	@Inject(method = "isTargetPos",
+			at = @At(value = "FIELD", target = "Lnet/minecraft/block/Blocks;FARMLAND:Lnet/minecraft/block/Block;"),
+			cancellable = true,
+			locals = LocalCapture.CAPTURE_FAILHARD
+	)
+	private void terraformDirt$onIsTargetBlock(WorldView world, BlockPos pos, CallbackInfoReturnable<Boolean> cir, BlockState state) {
 		Block block = state.getBlock();
 		if (block instanceof FarmlandBlock && state.isIn(TerraformDirtBlockTags.FARMLAND) && this.wantsCarrots && !this.hasTarget) {
 			state = world.getBlockState(pos.up());
@@ -33,7 +36,7 @@ public class MixinRabbitEntity {
 
 			if (block instanceof CarrotsBlock && ((CarrotsBlock) block).isMature(state)) {
 				this.hasTarget = true;
-				info.setReturnValue(true);
+				cir.setReturnValue(true);
 			}
 		}
 	}

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinSpreadableBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinSpreadableBlock.java
@@ -7,25 +7,21 @@ import net.minecraft.block.SpreadableBlock;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
-import net.minecraft.world.WorldView;
 
 import com.terraformersmc.terraform.dirt.block.TerraformGrassBlock;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(SpreadableBlock.class)
 public abstract class MixinSpreadableBlock {
-	@Shadow
-	private static boolean canSpread(BlockState state, WorldView worldView, BlockPos pos) {
-		return false;
-	}
-
-	@Inject(method = "randomTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z"), locals = LocalCapture.CAPTURE_FAILHARD)
-	private void onScheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random, CallbackInfo info, BlockState defaultState, int i, BlockPos spreadingPos) {
+	@Inject(method = "randomTick",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z"),
+			locals = LocalCapture.CAPTURE_FAILHARD
+	)
+	private void terraformDirt$onScheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random, CallbackInfo info, BlockState defaultState, int i, BlockPos spreadingPos) {
 		Block grassBlock = TerraformGrassBlock.GRASS_SPREADS_TO.get(world.getBlockState(spreadingPos).getBlock());
 		if (grassBlock != null) {
 			BlockState grassDefaultState = grassBlock.getDefaultState();

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinStemBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinStemBlock.java
@@ -3,22 +3,25 @@ package com.terraformersmc.terraform.dirt.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.terraformersmc.terraform.dirt.TerraformDirtBlockTags;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.StemBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-@Mixin(CropBlock.class)
-public class MixinCropBlock {
+@Mixin(StemBlock.class)
+public class MixinStemBlock {
 	@WrapOperation(
-			method = "getAvailableMoisture",
+			method = "randomTick",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z")
 	)
 	@SuppressWarnings("unused")
-	private static boolean terraformDirt$isOnFarmland(BlockState instance, Block block, Operation<Boolean> original) {
+	private boolean terraformDirt$isOnFarmland(BlockState instance, Block block, Operation<Boolean> operation) {
 		if (Blocks.FARMLAND.equals(block) && instance.isIn(TerraformDirtBlockTags.FARMLAND)) {
 			return true;
 		}
 
-		return original.call(instance, block);
+		return operation.call(instance, block);
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinSugarCaneBlock.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinSugarCaneBlock.java
@@ -1,35 +1,27 @@
 package com.terraformersmc.terraform.dirt.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.terraformersmc.terraform.dirt.TerraformDirtBlockTags;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.SugarCaneBlock;
-import net.minecraft.fluid.FluidState;
-import net.minecraft.registry.tag.FluidTags;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.world.WorldView;
+import net.minecraft.registry.tag.TagKey;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(SugarCaneBlock.class)
 public class MixinSugarCaneBlock {
-	@Inject(method = "canPlaceAt", at = @At("HEAD"), cancellable = true)
-	private void canPlaceAt(BlockState state, WorldView world, BlockPos pos, CallbackInfoReturnable<Boolean> info) {
-		BlockPos downPos = pos.down();
-
-		if (world.getBlockState(downPos).isIn(TerraformDirtBlockTags.SOIL)) {
-
-			for(Direction direction: Direction.Type.HORIZONTAL) {
-				BlockState candidateState = world.getBlockState(downPos.offset(direction));
-				FluidState fluidState = world.getFluidState(downPos.offset(direction));
-
-				if (fluidState.isIn(FluidTags.WATER) || candidateState.getBlock() == Blocks.FROSTED_ICE) {
-					info.setReturnValue(true);
-				}
-			}
+	@WrapOperation(
+			method = "canPlaceAt",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isIn(Lnet/minecraft/registry/tag/TagKey;)Z", ordinal = 0)
+	)
+	@SuppressWarnings("unused")
+	private boolean terraformDirt$canPlaceOnSoil(BlockState instance, TagKey<Block> dirtTag, Operation<Boolean> operation) {
+		if (instance.isIn(TerraformDirtBlockTags.SOIL)) {
+			return true;
 		}
+
+		return operation.call(instance, dirtTag);
 	}
 }

--- a/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinTrunkPlacer.java
+++ b/terraform-dirt-api-v1/src/main/java/com/terraformersmc/terraform/dirt/mixin/MixinTrunkPlacer.java
@@ -23,14 +23,13 @@ import net.minecraft.world.gen.trunk.TrunkPlacer;
 @Mixin(TrunkPlacer.class)
 public class MixinTrunkPlacer {
 	@Inject(method = "setToDirt", at = @At("HEAD"), cancellable = true)
-	private static void notAlwaysDirt(TestableWorld world, BiConsumer<BlockPos, BlockState> replacer, Random random, BlockPos pos, TreeFeatureConfig config, CallbackInfo ci) {
-		if (!world.testBlockState(pos, state -> state.isIn(TerraformDirtBlockTags.SOIL))) {
-			return;
+	private static void terraformDirt$notAlwaysDirt(TestableWorld world, BiConsumer<BlockPos, BlockState> replacer, Random random, BlockPos pos, TreeFeatureConfig config, CallbackInfo ci) {
+		if (world.testBlockState(pos, state -> state.isIn(TerraformDirtBlockTags.SOIL))) {
+			Block dirt = TerraformDirtRegistry.getFromWorld(world, pos).map(DirtBlocks::getDirt).orElse(Blocks.DIRT);
+
+			replacer.accept(pos, dirt.getDefaultState());
+
+			ci.cancel();
 		}
-
-		Block dirt = TerraformDirtRegistry.getFromWorld(world, pos).map(DirtBlocks::getDirt).orElse(Blocks.DIRT);
-
-		replacer.accept(pos, dirt.getDefaultState());
-		ci.cancel();
 	}
 }

--- a/terraform-dirt-api-v1/src/main/resources/mixins.terraform-dirt.json
+++ b/terraform-dirt-api-v1/src/main/resources/mixins.terraform-dirt.json
@@ -3,20 +3,21 @@
   "package": "com.terraformersmc.terraform.dirt.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-	"MixinAlterGroundTreeDecorator",
-	"MixinAnimalEntity",
-	"MixinCropBlock",
-	"MixinEatGrassGoal",
-	"MixinFarmlandBlock",
-	"MixinFeature",
-	"MixinPlantBlock",
-	"MixinPlantingOnFarmland",
-	"MixinRabbitEntity",
-	"MixinSpreadableBlock",
-	"MixinSugarCaneBlock",
-	"MixinTrunkPlacer"
+    "MixinAlterGroundTreeDecorator",
+    "MixinAnimalEntity",
+    "MixinCropBlock",
+    "MixinEatGrassGoal",
+    "MixinFarmlandBlock",
+    "MixinFeature",
+    "MixinPlantBlock",
+    "MixinPlantingOnFarmland",
+    "MixinRabbitEntity",
+    "MixinSpreadableBlock",
+    "MixinStemBlock",
+    "MixinSugarCaneBlock",
+    "MixinTrunkPlacer"
   ],
   "injectors": {
-	"defaultRequire": 1
+    "defaultRequire": 1
   }
 }

--- a/terraform-tree-api-v1/src/main/java/com/terraformersmc/terraform/tree/mixin/MixinTrunkPlacer.java
+++ b/terraform-tree-api-v1/src/main/java/com/terraformersmc/terraform/tree/mixin/MixinTrunkPlacer.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(TrunkPlacer.class)
 public class MixinTrunkPlacer {
 	@Inject(method = "setToDirt", at = @At("HEAD"), cancellable = true)
-	private static void notAlwaysDirt(TestableWorld world, BiConsumer<BlockPos, BlockState> replacer, Random random, BlockPos pos, TreeFeatureConfig config, CallbackInfo ci) {
+	private static void terraformTree$notAlwaysDirt(TestableWorld world, BiConsumer<BlockPos, BlockState> replacer, Random random, BlockPos pos, TreeFeatureConfig config, CallbackInfo ci) {
 		if (world.testBlockState(pos, state -> state.isIn(BlockTags.SAND))) {
 			ci.cancel();
 		}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntity.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntity.java
@@ -4,7 +4,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import com.terraformersmc.terraform.boat.api.TerraformBoatType;
 import com.terraformersmc.terraform.boat.impl.entity.TerraformBoatHolder;
 
 import net.minecraft.entity.vehicle.BoatEntity;
@@ -13,10 +12,9 @@ import net.minecraft.item.ItemConvertible;
 @Mixin(BoatEntity.class)
 public class MixinBoatEntity {
 	@ModifyArg(method = "fall(DZLnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V", index = 0, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/vehicle/BoatEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;", ordinal = 0))
-	private ItemConvertible replaceTerraformPlanksDropItem(ItemConvertible original) {
-		if ((Object) this instanceof TerraformBoatHolder) {
-			TerraformBoatType boat = ((TerraformBoatHolder) (Object) this).getTerraformBoat();
-			return boat.getPlanks();
+	private ItemConvertible terraformWood$replacePlanksDropItem(ItemConvertible original) {
+		if (this instanceof TerraformBoatHolder terraformBoatHolder) {
+			return terraformBoatHolder.getTerraformBoat().getPlanks();
 		}
 
 		return original;

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntityRenderer.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/boat/impl/mixin/MixinBoatEntityRenderer.java
@@ -2,13 +2,14 @@ package com.terraformersmc.terraform.boat.impl.mixin;
 
 import java.util.Map;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.datafixers.util.Pair;
 import com.terraformersmc.terraform.boat.impl.client.TerraformBoatEntityRenderer;
 import com.terraformersmc.terraform.boat.impl.entity.TerraformBoatHolder;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,11 +21,15 @@ import net.minecraft.util.Identifier;
 @Mixin(BoatEntityRenderer.class)
 @Environment(EnvType.CLIENT)
 public class MixinBoatEntityRenderer {
-	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;"))
-	private Object getTerraformBoatTextureAndModel(Map<BoatEntity.Type, Pair<Identifier, BoatEntityModel>> map, Object type, BoatEntity entity) {
-		if (entity instanceof TerraformBoatHolder && (Object) this instanceof TerraformBoatEntityRenderer) {
-			return ((TerraformBoatEntityRenderer) (Object) this).getTextureAndModel((TerraformBoatHolder) entity);
+	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;"))
+	@SuppressWarnings("unused")
+	private Object terraformWood$getBoatTextureAndModel(Map<BoatEntity.Type, Pair<Identifier, BoatEntityModel>> instance, Object type, Operation<Object> original, BoatEntity entity) {
+		//noinspection ConstantConditions
+		if (entity instanceof TerraformBoatHolder terraformEntity &&
+				(Object) this instanceof TerraformBoatEntityRenderer terraformRenderer) {
+			return terraformRenderer.getTextureAndModel(terraformEntity);
 		}
-		return map.get(type);
+
+		return original.call(instance, type);
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/mixin/MixinRenderLayers.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/leaves/mixin/MixinRenderLayers.java
@@ -1,6 +1,7 @@
 package com.terraformersmc.terraform.leaves.mixin;
 
 import com.terraformersmc.terraform.wood.block.SmallLogBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderLayers;
@@ -22,9 +23,10 @@ public class MixinRenderLayers {
 	private static boolean fancyGraphicsOrBetter;
 
 	@Inject(method = "getBlockLayer", at = @At("HEAD"), cancellable = true)
-	private static void onGetBlockRenderLayer(BlockState state, CallbackInfoReturnable<RenderLayer> info) {
-		if (state.getBlock() instanceof ExtendedLeavesBlock || state.getBlock() instanceof SmallLogBlock && state.get(SmallLogBlock.HAS_LEAVES)) {
-			info.setReturnValue(fancyGraphicsOrBetter ? RenderLayer.getCutoutMipped() : RenderLayer.getSolid());
+	private static void terraformWood$onGetBlockRenderLayer(BlockState state, CallbackInfoReturnable<RenderLayer> cir) {
+		Block block = state.getBlock();
+		if (block instanceof ExtendedLeavesBlock || block instanceof SmallLogBlock && state.get(SmallLogBlock.HAS_LEAVES)) {
+			cir.setReturnValue(fancyGraphicsOrBetter ? RenderLayer.getCutoutMipped() : RenderLayer.getSolid());
 		}
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinAbstractBlockSettings.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinAbstractBlockSettings.java
@@ -16,9 +16,10 @@ public class MixinAbstractBlockSettings implements BlockSettingsLock {
 	private boolean terraform$locked = false;
 
 	@Inject(method = "sounds", at = @At("HEAD"), cancellable = true)
-	private void terraform$preventSoundsOverride(CallbackInfoReturnable<AbstractBlock.Settings> ci) {
+	private void terraformWood$preventSoundsOverride(CallbackInfoReturnable<AbstractBlock.Settings> cir) {
 		if (this.terraform$locked) {
-			ci.setReturnValue((AbstractBlock.Settings) (Object) this);
+			//noinspection ConstantConditions
+			cir.setReturnValue((AbstractBlock.Settings) (Object) this);
 			this.terraform$locked = false;
 		}
 	}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinBlockEntityType.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinBlockEntityType.java
@@ -15,7 +15,7 @@ import net.minecraft.block.entity.BlockEntityType;
 @Mixin(BlockEntityType.class)
 public class MixinBlockEntityType {
 	@Inject(method = "supports", at = @At("HEAD"), cancellable = true)
-	private void supports(BlockState state, CallbackInfoReturnable<Boolean> info) {
+	private void terraformWood$signSupports(BlockState state, CallbackInfoReturnable<Boolean> cir) {
 		Block block = state.getBlock();
 
 		if (block instanceof TerraformSign) {
@@ -27,7 +27,7 @@ public class MixinBlockEntityType {
 				return;
 			}
 
-			info.setReturnValue(true);
+			cir.setReturnValue(true);
 		}
 	}
 }

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinHangingSignBlockEntityRenderer.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinHangingSignBlockEntityRenderer.java
@@ -16,10 +16,10 @@ import com.terraformersmc.terraform.sign.TerraformSign;
 @Environment(EnvType.CLIENT)
 public abstract class MixinHangingSignBlockEntityRenderer extends MixinSignBlockEntityRenderer {
 	@Inject(method = "getTextureId", at = @At("HEAD"), cancellable = true)
-	private void getHangingSignTextureId(CallbackInfoReturnable<SpriteIdentifier> ci) {
+	private void terraformWood$getHangingSignTextureId(CallbackInfoReturnable<SpriteIdentifier> cir) {
 		if (this.terraform$renderedBlockEntity != null) {
 			if (this.terraform$renderedBlockEntity.getCachedState().getBlock() instanceof TerraformSign signBlock) {
-				ci.setReturnValue(new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, signBlock.getTexture()));
+				cir.setReturnValue(new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, signBlock.getTexture()));
 			}
 		}
 	}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinHangingSignEditScreen.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinHangingSignEditScreen.java
@@ -23,7 +23,7 @@ public class MixinHangingSignEditScreen {
 	private Identifier texture;
 
 	@Inject(method = "<init>", at = @At("TAIL"))
-	private void initSignTextureId(SignBlockEntity signBlockEntity, boolean front, boolean filtered, CallbackInfo ci) {
+	private void terraformWood$initSignTextureId(SignBlockEntity signBlockEntity, boolean front, boolean filtered, CallbackInfo ci) {
 		if (signBlockEntity.getCachedState().getBlock() instanceof TerraformHangingSign signBlock) {
 			Identifier guiTexture = signBlock.getGuiTexture();
 			this.texture = new Identifier(guiTexture.getNamespace(), guiTexture.getPath() + ".png");

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignBlockEntityRenderer.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignBlockEntityRenderer.java
@@ -30,17 +30,17 @@ public abstract class MixinSignBlockEntityRenderer {
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/entity/SignBlockEntityRenderer;renderSign(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/block/WoodType;Lnet/minecraft/client/model/Model;)V")
 	)
 	@SuppressWarnings("unused")
-	private void setRenderedBlockEntity(SignBlockEntityRenderer instance, MatrixStack matrices, VertexConsumerProvider verticesProvider, int light, int overlay, WoodType type, Model model, Operation<Void> original, SignBlockEntity signBlockEntity) {
+	private void terraformWood$setRenderedBlockEntity(SignBlockEntityRenderer instance, MatrixStack matrices, VertexConsumerProvider verticesProvider, int light, int overlay, WoodType type, Model model, Operation<Void> original, SignBlockEntity signBlockEntity) {
 		this.terraform$renderedBlockEntity = signBlockEntity;
 		original.call(instance, matrices, verticesProvider, light, overlay, type, model);
 		this.terraform$renderedBlockEntity = null;
 	}
 
 	@Inject(method = "getTextureId", at = @At("HEAD"), cancellable = true)
-	private void getSignTextureId(CallbackInfoReturnable<SpriteIdentifier> ci) {
+	private void terraformWood$rendererSignTextureId(CallbackInfoReturnable<SpriteIdentifier> cir) {
 		if (this.terraform$renderedBlockEntity != null) {
 			if (this.terraform$renderedBlockEntity.getCachedState().getBlock() instanceof TerraformSign signBlock) {
-				ci.setReturnValue(new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, signBlock.getTexture()));
+				cir.setReturnValue(new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, signBlock.getTexture()));
 			}
 		}
 	}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinSignEditScreen.java
@@ -22,7 +22,7 @@ public class MixinSignEditScreen {
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/TexturedRenderLayers;getSignTextureId(Lnet/minecraft/block/WoodType;)Lnet/minecraft/client/util/SpriteIdentifier;")
 	)
 	@SuppressWarnings("unused")
-	private SpriteIdentifier getTerraformSignTextureId(WoodType type, Operation<SpriteIdentifier> original, DrawContext drawContext, BlockState state) {
+	private SpriteIdentifier terraformWood$editSignTextureId(WoodType type, Operation<SpriteIdentifier> original, DrawContext drawContext, BlockState state) {
 		if (state.getBlock() instanceof TerraformSign signBlock) {
 			return new SpriteIdentifier(TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, signBlock.getTexture());
 		}

--- a/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinTexturedRenderLayers.java
+++ b/terraform-wood-api-v1/src/main/java/com/terraformersmc/terraform/sign/mixin/MixinTexturedRenderLayers.java
@@ -14,8 +14,8 @@ import net.minecraft.client.util.SpriteIdentifier;
 @Mixin(TexturedRenderLayers.class)
 public class MixinTexturedRenderLayers {
 	@Inject(method = "addDefaultTextures", at = @At("RETURN"))
-	private static void injectTerrestriaSigns(Consumer<SpriteIdentifier> consumer, CallbackInfo info) {
-		for(SpriteIdentifier identifier: SpriteIdentifierRegistry.INSTANCE.getIdentifiers()) {
+	private static void terraformWood$injectSignTextures(Consumer<SpriteIdentifier> consumer, CallbackInfo ci) {
+		for (SpriteIdentifier identifier: SpriteIdentifierRegistry.INSTANCE.getIdentifiers()) {
 			consumer.accept(identifier);
 		}
 	}


### PR DESCRIPTION
I've gone through all the mixins in Terraform API and tried to consolidate the style and modernize, particularly with an eye to mod compatibility.  Programming being what it is, probably nobody will completely agree with my style; here's your chance to change it.  :P

There are a couple of behavioral changes here also.  For example, we have not synced the game event in `FarmlandBlock.setToDirt()` like vanilla does; now we will.  PathBlock now relies on `FarmlandBlock.setToDirt()` (no longer overriding what vanilla does), consolidating the block conversion and entity handling into a single code pathway which relies on the expansion of `TerraformDirtRegistry.getFromWorld()` behavior.  The Redirect of `map.get()` in `MixinBoatEntityRenderer` has been changed to a WrapOperation, which improves compatibility but does mean we will execute vanilla code we did not execute previously.

- Deprecate 2-arg DirtPathBlock constructor in favor of new one-arg (like FarmlandBlock)
- TerraformDirtRegistry.getFromWorld now finds any DirtBlocks variant (added farmland and path)
* Follow vanilla changes in MixinFarmlandBlock
* Consolidate mixin code style (likely to spur some debate)
* Update to WrapOperation: MixinAnimalEntity.spawnOnCustomGrass, MixinSugarCaneBlock.canPlaceOnSoil, MixinBoatEntityRenderer.getBoatTextureAndModel

I discovered our Farmland blocks don't support gourd growth while researching #22 and I have fixed this with a mixin to StemBlock.  While checking other uses of Blocks.FARMLAND I noticed we have a lot of mixins to different instances of `BlockState.isOf(Blocks.FARMLAND)` and there is little consistency in how they are implemented.  a7d4e81 makes all these implementations alike.

- Allow gourds to grow onto our Farmland blocks
- Allow pitcher plants to be planted on our Farmland blocks
- Refactor Farmland mixins a bit more to be consistent
